### PR TITLE
Fix for glossary tables.

### DIFF
--- a/modules/tei2fo.xql
+++ b/modules/tei2fo.xql
@@ -473,7 +473,7 @@ declare function tei2fo:cell($node as element(tei:cell), $options) as element() 
             then attribute class {'label'} 
             else ()
             }
-            {tei2fo:recurse($node, $options)}
+            <fo:block>{tei2fo:recurse($node, $options)}</fo:block>
             </fo:table-cell>
 };
 


### PR DESCRIPTION
The content of fo:cell has to be an fo:* element. The fix considers that the current or future tables have only text as content of tei:cell elements. For other contents, this solution has to be refined by considering that contents.